### PR TITLE
Removing the master and slave words

### DIFF
--- a/Tukey/tukey_middleware/doc/conf.py
+++ b/Tukey/tukey_middleware/doc/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'tukey_middleware'

--- a/Tukey/tukey_middleware/tukey_middleware/tests/services/openstack_mock.py
+++ b/Tukey/tukey_middleware/tukey_middleware/tests/services/openstack_mock.py
@@ -270,7 +270,7 @@ def images(project_id):
                 }
             ],
             "id": "d892dfaf-2a5a-4084-bcaa-948e1acf932e",
-            "name": "slave_v22",
+            "name": "subordinate_v22",
             "created": "2013-07-17T14:56:00Z",
             "minDisk": 0,
             "server": {
@@ -361,7 +361,7 @@ def images(project_id):
                 }
             ],
             "id": "0a97a0b3-ee4f-4041-aa0b-b7febb4d5072",
-            "name": "hadoop_slave4",
+            "name": "hadoop_subordinate4",
             "created": "2013-07-17T14:27:04Z",
             "minDisk": 0,
             "server": {

--- a/parcel/docs/source/conf.py
+++ b/parcel/docs/source/conf.py
@@ -49,8 +49,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Parcel'
@@ -229,7 +229,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  (master_doc, 'Parcel.tex', u'Parcel Documentation',
+  (main_doc, 'Parcel.tex', u'Parcel Documentation',
    u'Joshua Miller and Mark Murphy', 'manual'),
 ]
 
@@ -259,7 +259,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'parcel', u'Parcel Documentation',
+    (main_doc, 'parcel', u'Parcel Documentation',
      [author], 1)
 ]
 
@@ -273,7 +273,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  (master_doc, 'Parcel', u'Parcel Documentation',
+  (main_doc, 'Parcel', u'Parcel Documentation',
    author, 'Parcel', 'One line description of project.',
    'Miscellaneous'),
 ]


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.